### PR TITLE
pass plain string to custom formatter; omit undefined formatting output

### DIFF
--- a/lib/gulp-print.js
+++ b/lib/gulp-print.js
@@ -22,7 +22,12 @@ print = function(format) {
     };
   }
   return map(function(file, cb) {
-    print.log(format(colors.magenta(path.relative(process.cwd(), file.path))));
+    var filepath, formatted;
+    filepath = path.relative(process.cwd(), file.path);
+    formatted = format(colors.magenta(filepath), filepath);
+    if (formatted) {
+      print.log(formatted);
+    }
     return cb(null, file);
   });
 };

--- a/src/gulp-print.coffee
+++ b/src/gulp-print.coffee
@@ -13,7 +13,9 @@ print = (format) ->
   format ?= (filepath) -> filepath
 
   map (file, cb) ->
-    print.log format colors.magenta path.relative process.cwd(), file.path
+    filepath = path.relative process.cwd(), file.path
+    formatted = format colors.magenta(filepath), filepath
+    print.log formatted if formatted
     cb null, file
 
 print.log = log


### PR DESCRIPTION
patch for #3 that should be backwards compatible

also omits any `undefined` formatter output
