### PR TITLE
Add color param to log

### DIFF
--- a/src/gulp-print.coffee
+++ b/src/gulp-print.coffee
@@ -3,8 +3,9 @@ map = require 'map-stream'
 path = require 'path'
 
 log = ->
-  sig = "[#{green('gulp')}]"
-  args = Array.prototype.slice.call arguments
+  color = arguments[0]
+  sig = if color then "[#{green('gulp')}]" else "[gulp]"
+  args = Array.prototype.slice.call arguments, 1
   args.unshift sig
 
   console.log.apply console, args
@@ -19,7 +20,7 @@ print = (options = {}) ->
     filepath = path.relative process.cwd(), file.path
     filepath = magenta(filepath) if colors isnt false
     formatted = format filepath
-    print.log formatted if formatted
+    print.log colors, formatted if formatted
     cb null, file
 
 print.log = log


### PR DESCRIPTION
Fixes #5, note that since `.log()` is an exported function, this commit is not backwards compatible for people who previously used `.log()` directly. There may be a different way to handle this and still be backwards compat (store color in global state) but I'll leave that up to you. If you merge this in, please bump the major version of this lib.